### PR TITLE
Txpipe update + some fixes

### DIFF
--- a/tests/test_covariance_fourier_base.py
+++ b/tests/test_covariance_fourier_base.py
@@ -112,7 +112,7 @@ def test__get_covariance_block_for_sacc():
         cov2 = cb.get_covariance_block(trs1, trs2) + 1e-100
         cov2 = cov2.reshape(16, ncell1, 16, ncell2)[:, 0, :, 0]
 
-        assert np.max(np.abs(cov1/cov2 - 1)) < 1e-10
+        assert np.max(np.abs(cov1 / cov2 - 1)) < 1e-10
 
 
 def test_get_datatypes_from_ncell():

--- a/tests/test_covariance_fourier_ssc.py
+++ b/tests/test_covariance_fourier_ssc.py
@@ -203,9 +203,7 @@ def test_get_covariance_block(tracer_comb1, tracer_comb2):
 
     assert cov_ssc_zb.shape == (ell.size * ncell1, ell.size * ncell2)
     # Check the blocks
-    cov_ssc_zb = cov_ssc_zb.reshape(
-        (ell.size, ncell1, ell.size, ncell2)
-    )
+    cov_ssc_zb = cov_ssc_zb.reshape((ell.size, ncell1, ell.size, ncell2))
     # Check the reshape has the correct ordering
     assert np.all(cov_ssc_zb[:, 0, :, 0] == cov_ssc)
     cov_ssc_zb[:, 0, :, 0] -= cov_ssc

--- a/tests/test_covariance_fourier_ssc.py
+++ b/tests/test_covariance_fourier_ssc.py
@@ -202,12 +202,11 @@ def test_get_covariance_block(tracer_comb1, tracer_comb2):
         ncell2 += 1
 
     assert cov_ssc_zb.shape == (ell.size * ncell1, ell.size * ncell2)
-    # Check the reshape has the correct ordering
-    assert np.all(cov_ssc_zb[:16][:, :16] == cov_ssc)
     # Check the blocks
     cov_ssc_zb = cov_ssc_zb.reshape(
-        (ell.size, ncell1, ell.size, ncell2), order=cssc._reshape_order
+        (ell.size, ncell1, ell.size, ncell2)
     )
+    # Check the reshape has the correct ordering
     assert np.all(cov_ssc_zb[:, 0, :, 0] == cov_ssc)
     cov_ssc_zb[:, 0, :, 0] -= cov_ssc
     assert np.all(cov_ssc_zb == np.zeros_like(cov_ssc_zb))

--- a/tests/test_covariance_gaussian_fsky.py
+++ b/tests/test_covariance_gaussian_fsky.py
@@ -100,8 +100,8 @@ def test_Fourier_get_covariance_block():
     )
 
     nbpw = lb.size
-    assert np.all(cov2b[:nbpw][:, :nbpw] == cov2)
-    cov2b = cov2b.reshape((nbpw, 4, nbpw, 4), order="F")
+    cov2b = cov2b.reshape((nbpw, 4, nbpw, 4))
+    assert np.all(cov2b[:, 0, :, 0] == cov2)
     cov2b[:, 0, :, 0] -= cov2
     assert not np.any(cov2b)
 

--- a/tests/test_covariance_real_base.py
+++ b/tests/test_covariance_real_base.py
@@ -27,7 +27,6 @@ class CovarianceRealTester(CovarianceReal):
 
 class CovarianceProjectedRealTester(CovarianceProjectedReal):
     fourier = None
-    _reshape_order = "F"
 
     def _get_fourier_block(self, tracer_comb1, tracer_comb2):
         super().get_covariance_block(tracer_comb1, tracer_comb2)

--- a/tjpcov/covariance_builder.py
+++ b/tjpcov/covariance_builder.py
@@ -232,7 +232,8 @@ class CovarianceBuilder(ABC):
         """
         Return the covariance block for the two pair of tracers. This can have
         all elements. This is what you would get from an external code, for
-        instance.
+        instance. For Fourier space covariances, we assume the same order as in
+        NaMaster.
 
         Parameters:
         -----------

--- a/tjpcov/covariance_builder.py
+++ b/tjpcov/covariance_builder.py
@@ -1154,7 +1154,5 @@ class CovarianceProjectedReal(CovarianceReal):
                 if auto:
                     cov[:, j, :, i] = cov[:, i, :, j].T
 
-        cov = cov.reshape(
-            (nbpw * len(data_types1), nbpw * len(data_types2))
-        )
+        cov = cov.reshape((nbpw * len(data_types1), nbpw * len(data_types2)))
         return cov

--- a/tjpcov/covariance_builder.py
+++ b/tjpcov/covariance_builder.py
@@ -639,8 +639,12 @@ class CovarianceFourier(CovarianceBuilder):
         ncell2 = self.get_tracer_comb_ncell(tracer_comb2)
         dtypes2 = self.get_datatypes_from_ncell(ncell2)
 
-        # The reshape works for the NaMaster ordering with order 'C'
-        # If the blocks are ordered as in the sacc file, you need order 'F'
+        # The reshape below assumes that the covariances from
+        # `get_covariance_block` follow the NaMaster ordering. This is because
+        # NaMaster is the main code at the moment. If in the future we have new
+        # ways of comuting the covariance that follow a different ordering, eg.
+        # Cell[:, None] * Cell[None, :], as in sacc, we could modify this and
+        # make this a NaMaster specific method.
         cov = self.get_covariance_block(tracer_comb1, tracer_comb2, **kwargs)
         cov = cov.reshape(
             (nbpw, ncell1, nbpw, ncell2),

--- a/tjpcov/covariance_fourier_gaussian_nmt.py
+++ b/tjpcov/covariance_fourier_gaussian_nmt.py
@@ -15,7 +15,6 @@ class FourierGaussianNmt(CovarianceFourier):
     """
 
     cov_type = "gauss"
-    _reshape_order = "C"
 
     def __init__(self, config):
         """
@@ -196,6 +195,7 @@ class FourierGaussianNmt(CovarianceFourier):
 
         fname = os.path.join(self.io.outdir, fname)
         if os.path.isfile(fname):
+            print(f"Loading saved covariance {fname}")
             cov = np.load(fname)["cov"]
             return cov
 

--- a/tjpcov/covariance_fourier_ssc.py
+++ b/tjpcov/covariance_fourier_ssc.py
@@ -14,7 +14,6 @@ class FourierSSCHaloModel(CovarianceFourier):
     """
 
     cov_type = "SSC"
-    _reshape_order = "F"
 
     def __init__(self, config):
         """
@@ -173,7 +172,7 @@ class FourierSSCHaloModel(CovarianceFourier):
         cov_full = np.zeros((nbpw, ncell1, nbpw, ncell2))
         cov_full[:, 0, :, 0] = cov_ssc
         cov_full = cov_full.reshape(
-            (nbpw * ncell1, nbpw * ncell2), order=self._reshape_order
+            (nbpw * ncell1, nbpw * ncell2)
         )
 
         np.savez_compressed(fname, cov=cov_full, cov_nob=cov_ssc)

--- a/tjpcov/covariance_fourier_ssc.py
+++ b/tjpcov/covariance_fourier_ssc.py
@@ -171,9 +171,7 @@ class FourierSSCHaloModel(CovarianceFourier):
         ncell2 = self.get_tracer_comb_ncell(tracer_comb2)
         cov_full = np.zeros((nbpw, ncell1, nbpw, ncell2))
         cov_full[:, 0, :, 0] = cov_ssc
-        cov_full = cov_full.reshape(
-            (nbpw * ncell1, nbpw * ncell2)
-        )
+        cov_full = cov_full.reshape((nbpw * ncell1, nbpw * ncell2))
 
         np.savez_compressed(fname, cov=cov_full, cov_nob=cov_ssc)
 

--- a/tjpcov/covariance_gaussian_fsky.py
+++ b/tjpcov/covariance_gaussian_fsky.py
@@ -175,9 +175,7 @@ class FourierGaussianFsky(CovarianceFourier):
             ncell2 = self.get_tracer_comb_ncell(tracer_comb2)
             cov_full = np.zeros((nbpw, ncell1, nbpw, ncell2))
             cov_full[:, 0, :, 0] = cov
-            cov_full = cov_full.reshape(
-                (nbpw * ncell1, nbpw * ncell2)
-            )
+            cov_full = cov_full.reshape((nbpw * ncell1, nbpw * ncell2))
             cov = cov_full
 
         return cov

--- a/tjpcov/covariance_gaussian_fsky.py
+++ b/tjpcov/covariance_gaussian_fsky.py
@@ -14,7 +14,6 @@ class FourierGaussianFsky(CovarianceFourier):
     # configuration given in the yaml file. Kept like this for now to check I
     # don't break the tests during the refactoring.
     cov_type = "gauss"
-    _reshape_order = "F"
 
     def __init__(self, config):
         """
@@ -177,7 +176,7 @@ class FourierGaussianFsky(CovarianceFourier):
             cov_full = np.zeros((nbpw, ncell1, nbpw, ncell2))
             cov_full[:, 0, :, 0] = cov
             cov_full = cov_full.reshape(
-                (nbpw * ncell1, nbpw * ncell2), order=self._reshape_order
+                (nbpw * ncell1, nbpw * ncell2)
             )
             cov = cov_full
 
@@ -191,7 +190,6 @@ class RealGaussianFsky(CovarianceProjectedReal):
     """
 
     cov_type = "gauss"
-    _reshape_order = "F"
     # Set the fourier attribute to None and set it later in the __init__
     fourier = None
 

--- a/tjpcov/covariance_io.py
+++ b/tjpcov/covariance_io.py
@@ -95,7 +95,7 @@ class CovarianceIO:
         output = os.path.join(self.get_outdir(), output)
 
         s = self.get_sacc_file().copy()
-        s.add_covariance(cov)
+        s.add_covariance(cov, overwrite=True)
 
         if os.path.isfile(output) and (not overwrite):
             date = datetime.utcnow()


### PR DESCRIPTION
I have solved the building of the matrix from the blocks. The reshaping was not working (even though the unit tests passed). I have added a new unit test to check that the order makes sense now. I have also compared the output with the gaussian sims in 4096 nside fourier covariance matrix that was obtained for the TXPipe paper. Here some numbers and below a plot of the logarithmic absolute magnitude relative difference between both matrices. As you can see, the chi2 is pretty much the same
```
max abs rdev diag 5.073366493579812e-07
max abs rdev 1-off diag 0.00029870120325070637
max abs rdev 2-off diag 1.4045054967715132e-05
max abs rdev 0.1497571259501531
number of elements with abs rdev > 1e-3 42
Compare chi2
10889.579466013645
10889.579788057401
```

![image](https://user-images.githubusercontent.com/17812754/205611945-0dd85c16-18ee-4076-b421-b3918e0c40c3.png)

I have also checked that the refactored `wigner_transform.py` does not break the Real space covariance:
```
xi diff 2.458415715353579e-06
max abs rdev diag 3.0167256048763136e-07
max abs rdev 1-off diag 4.964438110466318e-05
max abs rdev 2-off diag 4.9329188987368155e-05
max abs rdev 0.4280426719575654
number of elements with abs rdev > 1e-3 362
number of elements with abs rdev > 1e-2 36
Compare chi2
4293.008339413925
4293.008400966504
```
![image](https://user-images.githubusercontent.com/17812754/205616352-bfa6bcbb-4d3f-4837-b78b-24af9ab8921b.png)