### PR TITLE
Remove unneeded imports 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,9 @@ dependencies = [
     "pytest",
     "pyccl>=2.5.0",
     "sacc>=0.7",
-    "camb"
+    "camb",
+    "healpy",
+    "h5py"
 ]
 dynamic = ["version"]
 
@@ -45,17 +47,13 @@ doc = [
     "sphinx_rtd_theme",
 ]
 nmt = [
-    "healpy",
-    "pymaster>=1.4.0",
-    "h5py",
+    "pymaster>=1.4.0"
 ]
 mpi = [
     "mpi4py"
 ]
 full = [
-    "healpy",
     "pymaster>=1.4.0",
-    "h5py",
     "mpi4py",
     "sphinx",
     "sphinx-autoapi",

--- a/tests/test_covariance_gaussian_fsky.py
+++ b/tests/test_covariance_gaussian_fsky.py
@@ -7,7 +7,7 @@ import pyccl as ccl
 import pytest
 import shutil
 
-from tjpcov import bin_cov
+from tjpcov.wigner_transform import bin_cov
 from tjpcov.covariance_gaussian_fsky import (
     FourierGaussianFsky,
     RealGaussianFsky,

--- a/tests/test_covariance_real_base.py
+++ b/tests/test_covariance_real_base.py
@@ -3,7 +3,7 @@ import numpy as np
 import pytest
 import sacc
 
-from tjpcov import bin_cov, WignerTransform
+from tjpcov.wigner_transform import bin_cov, WignerTransform
 from tjpcov.covariance_builder import (
     CovarianceProjectedReal,
     CovarianceReal,

--- a/tjpcov/__init__.py
+++ b/tjpcov/__init__.py
@@ -1,12 +1,5 @@
 # flake8: noqa
 from .covariance_builder import CovarianceBuilder
-from .covariance_fourier_gaussian_nmt import FourierGaussianNmt
-from .covariance_fourier_ssc import FourierSSCHaloModel
-from .covariance_gaussian_fsky import (
-    FourierGaussianFsky,
-    RealGaussianFsky,
-)
-from .wigner_transform import bin_cov, WignerTransform
 
 
 def covariance_from_name(name):


### PR DESCRIPTION
Remove unneeded imports. Closes #58.

This will require update in TXPipe (https://github.com/LSSTDESC/TXPipe/blob/b4c2e9dcb131f0296d4a98c6e09a169e5fd30cbc/txpipe/covariance.py#L262).

Edit: The TXPipe update has been done here: https://github.com/LSSTDESC/TXPipe/pull/282