### PR TITLE
Updating TJPCov to require python 3.8 or above.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,10 +15,10 @@ jobs:
           access_token: ${{ github.token }}
 
       - uses: actions/checkout@v2
-      - name: Set up Python 3.7
+      - name: Set up Python 3.8
         uses: actions/setup-python@v2
         with:
-          python-version: '3.7'
+          python-version: '3.8'
 
       # TODO: Fix cache
       # Commented out because cache makes the actions to fail

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-20.04
   tools:
-    python: "3.7"
+    python: "3.8"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python=3.7
+  - python>=3.8
   # Installing TJPcov in two steps to avoid making NaMaster installation to
   # fail due to (https://github.com/LSSTDESC/NaMaster/issues/138)
   - tjpcov

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
 ]
 description = "Covariances for LSST DESC"
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 classifiers = [
     "Development Status :: 4 - Beta",
     "Programming Language :: Python :: 3",

--- a/tests/test_wigner_transform.py
+++ b/tests/test_wigner_transform.py
@@ -149,16 +149,17 @@ def test_wigner_d_parallel(s1, s2):
     ell = kwargs["ell"]
     wd = wigner_transform.wigner_d(s1, s2, theta, ell)
     wd2 = wigner_transform.wigner_d_parallel(s1, s2, theta, ell)
-    assert np.all(wd == wd2)
+    assert wd.flatten() == pytest.approx(wd2.flatten(), rel=1e-10)
 
     wd2 = wigner_transform.wigner_d_parallel(s1, s2, theta, ell, ncpu=4)
-    assert np.all(wd == wd2)
+    assert wd.flatten() == pytest.approx(wd2.flatten(), rel=1e-10)
 
     wd = wigner_transform.wigner_d(s1, s2, theta, ell, l_use_bessel=None)
     wd2 = wigner_transform.wigner_d_parallel(
         s1, s2, theta, ell, l_use_bessel=None
     )
-    assert np.all(wd == wd2)
+
+    assert wd.flatten() == pytest.approx(wd2.flatten(), rel=1e-10)
 
 
 def test_bin_cov():


### PR DESCRIPTION
Closes #85 

This probably should be merged **after** #84 is completed to avoid an (albeit small) merge conflict.  

All tests pass.  Also tested 3.9, 3.10, and 3.11.  

Would be nice to include in our CI build tests for 3.9, 3.10, and 3.11 to ease future upgrades.

