### PR TITLE
ssc: fixed a range

### DIFF
--- a/tjpcov/covariance_fourier_ssc.py
+++ b/tjpcov/covariance_fourier_ssc.py
@@ -104,7 +104,11 @@ class FourierSSCHaloModel(CovarianceFourier):
         # Use the a's in the pk spline
         na = ccl.ccllib.get_pk_spline_na(cosmo.cosmo)
         a, _ = ccl.ccllib.get_pk_spline_a(cosmo.cosmo, na, 0)
-        a = a[1 / a < z_max + 1]
+        # Cut the array for efficiency
+        sel = 1/a < z_max+1
+        # Include the next node so that z_max is in the range
+        sel[np.sum(~sel)-1] = True
+        a = a[sel]
 
         bias1 = self.bias_lens.get(tr[1], 1)
         bias2 = self.bias_lens.get(tr[2], 1)


### PR DESCRIPTION
Fixes the integration error in `ccl.covariances.angular_cl_cov_SSC` due to `sigma2_B` computed up to a lower redshift than required.