### PR TITLE
Updating TJPCov to require python >= 3.8

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,10 +15,10 @@ jobs:
           access_token: ${{ github.token }}
 
       - uses: actions/checkout@v2
-      - name: Set up Python 3.7
+      - name: Set up Python 3.8
         uses: actions/setup-python@v2
         with:
-          python-version: '3.7'
+          python-version: '3.8'
 
       # TODO: Fix cache
       # Commented out because cache makes the actions to fail

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-20.04
   tools:
-    python: "3.7"
+    python: "3.8"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python=3.7
+  - python>=3.8
   - mpi4py
   - pip
   - numpy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
 ]
 description = "Covariances for LSST DESC"
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 classifiers = [
     "Development Status :: 4 - Beta",
     "Programming Language :: Python :: 3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "pytest",
     "pytest-rerunfailures",
     "pyccl>=2.5.0",
-    "sacc>=0.7",
+    "sacc>=0.8",
     "camb",
     "healpy",
     "h5py"

--- a/tests/test_covariance_clusters.py
+++ b/tests/test_covariance_clusters.py
@@ -49,7 +49,7 @@ def mock_sacc():
     # hacks the class to work without building
     # an entire sacc file for this test.
     s.add_tracer(
-        "misc",
+        "Misc",
         "clusters_0_0",
         metadata={
             "Mproxy_name": "richness",

--- a/tests/test_covariance_fourier_base.py
+++ b/tests/test_covariance_fourier_base.py
@@ -20,7 +20,7 @@ def mock_sacc():
 
 
 def setup_module():
-    os.makedirs(OUTDIR)
+    os.makedirs(OUTDIR, exist_ok=True)
 
 
 def teardown_module():
@@ -41,7 +41,7 @@ def mock_cov_fourier():
 def get_dummy_sacc():
     s = sacc.Sacc()
     s.add_tracer(
-        "map", "PLAcv", quantity="cmb_convergence", spin=0, ell=None, beam=None
+        "Map", "PLAcv", quantity="cmb_convergence", spin=0, ell=None, beam=None
     )
     s.add_tracer(
         "NZ", "DESgc__0", quantity="galaxy_density", spin=0, nz=None, z=None
@@ -49,7 +49,7 @@ def get_dummy_sacc():
     s.add_tracer(
         "NZ", "DESwl__0", quantity="galaxy_shear", spin=2, nz=None, z=None
     )
-    s.add_tracer("misc", "ForError", quantity="generic")
+    s.add_tracer("Misc", "ForError", quantity="generic")
 
     return s
 

--- a/tests/test_covariance_fourier_gaussian_nmt.py
+++ b/tests/test_covariance_fourier_gaussian_nmt.py
@@ -138,7 +138,7 @@ def get_dummy_sacc():
     s.add_tracer(
         "NZ", "DESwl__0", quantity="galaxy_shear", spin=2, nz=None, z=None
     )
-    s.add_tracer("misc", "ForError", quantity="generic")
+    s.add_tracer("Misc", "ForError", quantity="generic")
 
     return s
 

--- a/tests/test_covariance_fourier_gaussian_nmt.py
+++ b/tests/test_covariance_fourier_gaussian_nmt.py
@@ -130,7 +130,7 @@ def get_data_cl(tr1, tr2, remove_be=False):
 def get_dummy_sacc():
     s = sacc.Sacc()
     s.add_tracer(
-        "map", "PLAcv", quantity="cmb_convergence", spin=0, ell=None, beam=None
+        "Map", "PLAcv", quantity="cmb_convergence", spin=0, ell=None, beam=None
     )
     s.add_tracer(
         "NZ", "DESgc__0", quantity="galaxy_density", spin=0, nz=None, z=None

--- a/tests/test_wigner_transform.py
+++ b/tests/test_wigner_transform.py
@@ -149,16 +149,17 @@ def test_wigner_d_parallel(s1, s2):
     ell = kwargs["ell"]
     wd = wigner_transform.wigner_d(s1, s2, theta, ell)
     wd2 = wigner_transform.wigner_d_parallel(s1, s2, theta, ell)
-    assert np.all(wd == wd2)
+    assert wd.flatten() == pytest.approx(wd2.flatten(), rel=1e-10)
 
     wd2 = wigner_transform.wigner_d_parallel(s1, s2, theta, ell, ncpu=4)
-    assert np.all(wd == wd2)
+    assert wd.flatten() == pytest.approx(wd2.flatten(), rel=1e-10)
 
     wd = wigner_transform.wigner_d(s1, s2, theta, ell, l_use_bessel=None)
     wd2 = wigner_transform.wigner_d_parallel(
         s1, s2, theta, ell, l_use_bessel=None
     )
-    assert np.all(wd == wd2)
+
+    assert wd.flatten() == pytest.approx(wd2.flatten(), rel=1e-10)
 
 
 def test_bin_cov():


### PR DESCRIPTION
Closes #85 

All tests pass. Also tested 3.9, 3.10, and 3.11.

Would be nice to include in our CI build tests for 3.9, 3.10, and 3.11 to ease future upgrades.