### PR TITLE
added more flexible binning

### DIFF
--- a/tjpcov/covariance_builder.py
+++ b/tjpcov/covariance_builder.py
@@ -751,7 +751,7 @@ class CovarianceFourier(CovarianceBuilder):
             for i in range(bpw.weight.shape[1]):
                 ell_edges[i] = bpw.values[bpw.weight[:, i] > 0][0]
                 if i == bpw.weight.shape[1] - 1:
-                    ell_edges[i+1] = bpw.values[bpw.weight[:, i] > 0][-1]
+                    ell_edges[i + 1] = bpw.values[bpw.weight[:, i] > 0][-1]
             return bpw.values, ell_eff, ell_edges
         else:
             return None

--- a/tjpcov/covariance_builder.py
+++ b/tjpcov/covariance_builder.py
@@ -725,8 +725,8 @@ class CovarianceFourier(CovarianceBuilder):
         return ell
 
     def get_binning_info(self):
-        """Return all ells used for the different bandpowers, their effective ell and
-        bandpower edges based on the SACC information.
+        """Return all ells used for the different bandpowers, their effective
+        ell and bandpower edges based on the SACC information.
 
         It assume that all tracers have the same bandpower windows.
 
@@ -744,13 +744,13 @@ class CovarianceFourier(CovarianceBuilder):
         inds = sacc_file.indices(data_type=dt, tracers=(tr1, tr2))
         bpw = sacc_file.get_bandpower_windows(inds)
         if bpw is not None:
-            ells = np.repeat(bpw.values, bpw.weight.shape[1]).reshape(
-                bpw.weight.shape)
+            ells = np.repeat(bpw.values, bpw.weight.shape[1])
+            ells = ells.reshape(bpw.weight.shape)
             ell_eff = np.average(ells, weights=bpw.weight, axis=0)
             ell_edges = np.zeros(bpw.weight.shape[1] + 1)
             for i in range(bpw.weight.shape[1]):
                 ell_edges[i] = bpw.values[bpw.weight[:, i] > 0][0]
-                if i == bpw.weight.shape[1]-1:
+                if i == bpw.weight.shape[1] - 1:
                     ell_edges[i+1] = bpw.values[bpw.weight[:, i] > 0][-1]
             return bpw.values, ell_eff, ell_edges
         else:

--- a/tjpcov/covariance_builder.py
+++ b/tjpcov/covariance_builder.py
@@ -723,6 +723,37 @@ class CovarianceFourier(CovarianceBuilder):
         ell, _ = sacc_file.get_ell_cl(dtype, *tracers)
 
         return ell
+    
+    def get_binning_info(self):
+        """Return all ells used for the different bandpowers, their effective ell and
+        bandpower edges based on the SACC information.
+
+        It assume that all tracers have the same bandpower windows.
+
+        Args:
+            sacc_data (:obj:`sacc.sacc.Sacc`): Data Sacc instance
+
+        Returns:
+            ells: Array with the ells to pass to theory prediction.
+            ell_eff: Array with effective ells from sacc
+            ell_edges: Array with bandpower edges (assumed to be contiguous).
+        """
+        sacc_file = self.io.get_sacc_file()
+        tr1, tr2 = sacc_file.get_tracer_combinations()[0]
+        dt = sacc_file.get_data_types(tracers=(tr1, tr2))[0]
+        inds = sacc_file.indices(data_type=dt, tracers=(tr1, tr2))
+        bpw = sacc_file.get_bandpower_windows(inds)
+        if bpw is not None:
+            ells = np.repeat(bpw.values, bpw.weight.shape[1]).reshape(bpw.weight.shape)
+            ell_eff = np.average(ells, weights=bpw.weight, axis=0)
+            ell_edges = np.zeros(bpw.weight.shape[1] + 1)
+            for i in range(bpw.weight.shape[1]):
+                ell_edges[i] = bpw.values[bpw.weight[:, i] > 0][0]
+                if i == bpw.weight.shape[1]-1:
+                    ell_edges[i+1] = bpw.values[bpw.weight[:, i] > 0][-1]
+            return bpw.values, ell_eff, ell_edges
+        else:
+            return None
 
     def get_sacc_with_concise_dtypes(self):
         """Return a copy of the sacc file with concise data types.

--- a/tjpcov/covariance_builder.py
+++ b/tjpcov/covariance_builder.py
@@ -723,7 +723,7 @@ class CovarianceFourier(CovarianceBuilder):
         ell, _ = sacc_file.get_ell_cl(dtype, *tracers)
 
         return ell
-    
+
     def get_binning_info(self):
         """Return all ells used for the different bandpowers, their effective ell and
         bandpower edges based on the SACC information.
@@ -744,7 +744,8 @@ class CovarianceFourier(CovarianceBuilder):
         inds = sacc_file.indices(data_type=dt, tracers=(tr1, tr2))
         bpw = sacc_file.get_bandpower_windows(inds)
         if bpw is not None:
-            ells = np.repeat(bpw.values, bpw.weight.shape[1]).reshape(bpw.weight.shape)
+            ells = np.repeat(bpw.values, bpw.weight.shape[1]).reshape(
+                bpw.weight.shape)
             ell_eff = np.average(ells, weights=bpw.weight, axis=0)
             ell_edges = np.zeros(bpw.weight.shape[1] + 1)
             for i in range(bpw.weight.shape[1]):

--- a/tjpcov/covariance_gaussian_fsky.py
+++ b/tjpcov/covariance_gaussian_fsky.py
@@ -50,8 +50,10 @@ class FourierGaussianFsky(CovarianceFourier):
             ell_edges = out[2]
             return ell, ell_eff, ell_edges
         else:
-            warnings.warn("No bandpower windows found, \
-                           falling back to linear method")
+            warnings.warn(
+                "No bandpower windows found, \
+                           falling back to linear method"
+            )
             ell_eff = self.get_ell_eff()
             nbpw = ell_eff.size
 
@@ -67,7 +69,8 @@ class FourierGaussianFsky(CovarianceFourier):
                 ell = np.arange(ell_min, ell_max + ell_delta - 2)
             else:
                 raise NotImplementedError(
-                    f"Binning {binning} not implemented yet")
+                    f"Binning {binning} not implemented yet"
+                )
 
             return ell, ell_eff, ell_edges
 

--- a/tjpcov/covariance_gaussian_fsky.py
+++ b/tjpcov/covariance_gaussian_fsky.py
@@ -43,7 +43,7 @@ class FourierGaussianFsky(CovarianceFourier):
         # TODO: This should be obtained from the sacc file or the input
         # configuration. Check how it is done in TXPipe:
         # https://github.com/LSSTDESC/TXPipe/blob/a9dfdb7809ac7ed6c162fd3930c643a67a
-        out = super().get_binning_info()
+        out = self.get_binning_info()
         if out is not None:
             ell = out[0]
             ell_eff = out[1]

--- a/tjpcov/covariance_gaussian_fsky.py
+++ b/tjpcov/covariance_gaussian_fsky.py
@@ -66,7 +66,8 @@ class FourierGaussianFsky(CovarianceFourier):
                 ell_edges = np.arange(ell_min, ell_max + 1, ell_delta)
                 ell = np.arange(ell_min, ell_max + ell_delta - 2)
             else:
-                raise NotImplementedError(f"Binning {binning} not implemented yet")
+                raise NotImplementedError(
+                    f"Binning {binning} not implemented yet")
 
             return ell, ell_eff, ell_edges
 

--- a/tjpcov/covariance_gaussian_fsky.py
+++ b/tjpcov/covariance_gaussian_fsky.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pyccl as ccl
+import warnings
 
 from .wigner_transform import bin_cov
 from .covariance_builder import CovarianceFourier, CovarianceProjectedReal
@@ -41,24 +42,33 @@ class FourierGaussianFsky(CovarianceFourier):
         """
         # TODO: This should be obtained from the sacc file or the input
         # configuration. Check how it is done in TXPipe:
-        # https://github.com/LSSTDESC/TXPipe/blob/a9dfdb7809ac7ed6c162fd3930c643a67afcd881/txpipe/covariance.py#L23
-        ell_eff = self.get_ell_eff()
-        nbpw = ell_eff.size
-
-        ellb_min, ellb_max = ell_eff.min(), ell_eff.max()
-        if binning == "linear":
-            del_ell = (ell_eff[1:] - ell_eff[:-1])[0]
-
-            ell_min = ellb_min - del_ell / 2
-            ell_max = ellb_max + del_ell / 2
-
-            ell_delta = (ell_max - ell_min) // nbpw
-            ell_edges = np.arange(ell_min, ell_max + 1, ell_delta)
-            ell = np.arange(ell_min, ell_max + ell_delta - 2)
+        # https://github.com/LSSTDESC/TXPipe/blob/a9dfdb7809ac7ed6c162fd3930c643a67a
+        out = super().get_binning_info()
+        if out is not None:
+            ell = out[0]
+            ell_eff = out[1]
+            ell_edges = out[2]
+            return ell, ell_eff, ell_edges
         else:
-            raise NotImplementedError(f"Binning {binning} not implemented yet")
+            warnings.warn("No bandpower windows found, \
+                           falling back to linear method")
+            ell_eff = self.get_ell_eff()
+            nbpw = ell_eff.size
 
-        return ell, ell_eff, ell_edges
+            ellb_min, ellb_max = ell_eff.min(), ell_eff.max()
+            if binning == "linear":
+                del_ell = (ell_eff[1:] - ell_eff[:-1])[0]
+
+                ell_min = ellb_min - del_ell / 2
+                ell_max = ellb_max + del_ell / 2
+
+                ell_delta = (ell_max - ell_min) // nbpw
+                ell_edges = np.arange(ell_min, ell_max + 1, ell_delta)
+                ell = np.arange(ell_min, ell_max + ell_delta - 2)
+            else:
+                raise NotImplementedError(f"Binning {binning} not implemented yet")
+
+            return ell, ell_eff, ell_edges
 
     def get_covariance_block(
         self,


### PR DESCRIPTION
Some of us have discussed online the possibility of adding more flexible binning for the covariance calculation using TJPCov, for example, reading bandpower windows. Here's a first draft implementation for that.