### PR TITLE
Convert fsky to float64

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -83,6 +83,11 @@ jobs:
         run: |
           export MAMBA_NO_BANNER=1
           mamba env update --file ${{ env.CONDA_ENV }}
+        
+      - name: Install git (needed by setuptools-scm)
+        run: |
+          mamba install -y git
+          git --version
 
       - name: Install TJPCov
         run: | 

--- a/tests/test_covariance_fourier_cNG.py
+++ b/tests/test_covariance_fourier_cNG.py
@@ -110,7 +110,7 @@ def get_fsky(tr1, tr2, tr3, tr4):
     m3 = hp.read_map(mf[tr3])
     m4 = hp.read_map(mf[tr4])
 
-    return np.mean(m1 * m2 * m3 * m4)
+    return np.float64(np.mean(m1 * m2 * m3 * m4)).item()
 
 
 def test_smoke():

--- a/tests/test_covariance_fourier_cNG.py
+++ b/tests/test_covariance_fourier_cNG.py
@@ -233,7 +233,6 @@ def test_get_covariance_block(cov_fcNG, tracer_comb1, tracer_comb2):
     )
 
     if calculate_with_hod:
-
         prof_2pt_hod = ccl.halos.profiles_2pt.Profile2ptHOD()
         prof_2pt_avg = ccl.halos.profiles_2pt.Profile2pt()
         HOD = ccl.halos.HaloProfileHOD

--- a/tests/test_covariance_fourier_cNG_fsky.py
+++ b/tests/test_covariance_fourier_cNG_fsky.py
@@ -101,7 +101,7 @@ def get_NFW_profile():
 def get_fsky(tr1, tr2, tr3, tr4):
     config = get_config()
     fsky = config["tjpcov"].get("fsky", None)
-    return fsky
+    return np.float64(fsky).item()
 
 
 def test_smoke():

--- a/tests/test_covariance_fourier_cNG_fsky.py
+++ b/tests/test_covariance_fourier_cNG_fsky.py
@@ -224,7 +224,6 @@ def test_get_covariance_block(cov_fcNG, tracer_comb1, tracer_comb2):
     )
 
     if calculate_with_hod:
-
         prof_2pt_hod = ccl.halos.profiles_2pt.Profile2ptHOD()
         prof_2pt_avg = ccl.halos.profiles_2pt.Profile2pt()
         HOD = ccl.halos.HaloProfileHOD

--- a/tests/test_covariance_fourier_gaussian_nmt.py
+++ b/tests/test_covariance_fourier_gaussian_nmt.py
@@ -559,9 +559,9 @@ def test_get_covariance_block(tracer_comb1, tracer_comb2):
 
     # Check that it runs if one of the masks does not overlap with the others
     if tracer_comb1 != tracer_comb2:
-        cnmt.mask_files[
-            tracer_comb1[0]
-        ] = "./tests/benchmarks/32_DES_tjpcov_bm/catalogs/mask_nonoverlapping.fits.gz"  # noqa: E501
+        cnmt.mask_files[tracer_comb1[0]] = (
+            "./tests/benchmarks/32_DES_tjpcov_bm/catalogs/mask_nonoverlapping.fits.gz"  # noqa: E501
+        )
         cov = cnmt.get_covariance_block(
             tracer_comb1, tracer_comb2, clobber=True
         )

--- a/tests/test_covariance_fourier_gaussian_nmt.py
+++ b/tests/test_covariance_fourier_gaussian_nmt.py
@@ -559,9 +559,9 @@ def test_get_covariance_block(tracer_comb1, tracer_comb2):
 
     # Check that it runs if one of the masks does not overlap with the others
     if tracer_comb1 != tracer_comb2:
-        cnmt.mask_files[tracer_comb1[0]] = (
-            "./tests/benchmarks/32_DES_tjpcov_bm/catalogs/mask_nonoverlapping.fits.gz"  # noqa: E501
-        )
+        cnmt.mask_files[
+            tracer_comb1[0]
+        ] = "./tests/benchmarks/32_DES_tjpcov_bm/catalogs/mask_nonoverlapping.fits.gz"  # noqa: E501
         cov = cnmt.get_covariance_block(
             tracer_comb1, tracer_comb2, clobber=True
         )

--- a/tjpcov/covariance_fourier_cNG.py
+++ b/tjpcov/covariance_fourier_cNG.py
@@ -65,7 +65,7 @@ class FouriercNGHaloModel(CovarianceFourier):
         """
         masks = self.get_masks_dict(tr, {})
         fsky = np.mean(masks[1] * masks[2] * masks[3] * masks[4])
-        return fsky
+        return np.float64(fsky).item() 
 
     def get_covariance_block(
         self,

--- a/tjpcov/covariance_fourier_cNG.py
+++ b/tjpcov/covariance_fourier_cNG.py
@@ -65,7 +65,7 @@ class FouriercNGHaloModel(CovarianceFourier):
         """
         masks = self.get_masks_dict(tr, {})
         fsky = np.mean(masks[1] * masks[2] * masks[3] * masks[4])
-        return np.float64(fsky).item() 
+        return np.float64(fsky).item()
 
     def get_covariance_block(
         self,

--- a/tjpcov/covariance_fourier_cNG_fsky.py
+++ b/tjpcov/covariance_fourier_cNG_fsky.py
@@ -1,6 +1,7 @@
 from .covariance_fourier_cNG import FouriercNGHaloModel
 import numpy as np
 
+
 class FouriercNGHaloModelFsky(FouriercNGHaloModel):
     """Class to compute the CellxCell Halo Model cNG Covariance."""
 

--- a/tjpcov/covariance_fourier_cNG_fsky.py
+++ b/tjpcov/covariance_fourier_cNG_fsky.py
@@ -1,5 +1,5 @@
 from .covariance_fourier_cNG import FouriercNGHaloModel
-
+import numpy as np
 
 class FouriercNGHaloModelFsky(FouriercNGHaloModel):
     """Class to compute the CellxCell Halo Model cNG Covariance."""
@@ -31,4 +31,4 @@ class FouriercNGHaloModelFsky(FouriercNGHaloModel):
         Returns:
             - (:obj:`float`): fractional sky area.
         """
-        return self.fsky
+        return np.float64(self.fsky).item()


### PR DESCRIPTION
Otherwise the tests in `tests/test_covariance_fourier_cNG.py` would fail since the CCL binding requires a double.