### PR TITLE
update readthedocs build requirements

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: actions/setup-python@v5
+        with:
+          # Use the same Python version as in pyproject.toml black config.
+          python-version: "3.13"
+
       - name: Run black
         uses: psf/black@stable
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
     name: Run Linters
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -48,12 +48,12 @@ jobs:
         runs-on: [ubuntu-latest, macos-latest]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Set up mamba
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
           channels: conda-forge
           python-version: ${{ matrix.python-version }}
@@ -130,7 +130,7 @@ jobs:
 
     steps:
       - name: Collect all coverage reports and publish to coveralls.io
-        uses: coverallsapp/github-action@master
+        uses: coverallsapp/github-action@v2
         with:
           carryforward: "run-3.10-ubuntu-latest,run-3.11-ubuntu-latest,run-3.12-ubuntu-latest,run-3.13-ubuntu-latest,run-3.10-macos-latest,run-3.11-macos-latest,run-3.12-macos-latest,run-3.13-macos-latest"
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
     name: Run Linters
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,12 +53,12 @@ jobs:
         runs-on: [ubuntu-latest, macos-latest]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up mamba
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@v4
         with:
           channels: conda-forge
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -135,3 +135,15 @@ jobs:
           carryforward: "run-3.10-ubuntu-latest,run-3.11-ubuntu-latest,run-3.12-ubuntu-latest,run-3.13-ubuntu-latest,run-3.10-macos-latest,run-3.11-macos-latest,run-3.12-macos-latest,run-3.13-macos-latest"
           github-token: ${{ secrets.GITHUB_TOKEN }}
           parallel-finished: true
+
+  all_tests_passed:
+    needs: [lint, tests]
+    name: All tests passed
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Check all jobs succeeded
+        run: |
+          if [[ "${{ needs.tests.result }}" != "success" || "${{ needs.lint.result }}" != "success" ]]; then
+            exit 1
+          fi

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,9 +7,9 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-20.04
+  os: ubuntu-24.04
   tools:
-    python: "3.8"
+    python: "3.12"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [tool.black]
 line-length = 79
 include = './*\.pyi?$|tests\/.*\.pyi?$|tjpcov\/.*\.pyi?$'
+target-version = ["py313"]
 
 [build-system]
 requires = ["setuptools>=61.0", "setuptools_scm[toml]>=6.2"]

--- a/run_tjpcov.py
+++ b/run_tjpcov.py
@@ -2,7 +2,6 @@
 
 from tjpcov.covariance_calculator import CovarianceCalculator
 
-
 if __name__ == "__main__":
     import argparse
 

--- a/tests/test_covariance_calculator.py
+++ b/tests/test_covariance_calculator.py
@@ -8,7 +8,6 @@ import numpy as np
 import sacc
 import shutil
 
-
 INPUT_YML = "./tests/data/conf_covariance_calculator.yml"
 OUTDIR = "./tests/tmp/"
 

--- a/tests/test_covariance_fourier_base.py
+++ b/tests/test_covariance_fourier_base.py
@@ -143,7 +143,7 @@ def test_get_ell_eff(mock_cov_fourier):
     bins = get_nmt_bin()
     ells = bins.get_effective_ells()
 
-    assert np.all(mock_cov_fourier.get_ell_eff() == ells)
+    assert pytest.approx(mock_cov_fourier.get_ell_eff(), rel=1e-10) == ells
 
 
 def test_get_sacc_with_concise_dtypes(mock_sacc, mock_cov_fourier):

--- a/tests/test_covariance_fourier_gaussian_nmt.py
+++ b/tests/test_covariance_fourier_gaussian_nmt.py
@@ -13,7 +13,6 @@ import yaml
 from tjpcov.covariance_fourier_gaussian_nmt import FourierGaussianNmt
 from tjpcov.covariance_io import CovarianceIO
 
-
 ROOT = "tests/benchmarks/32_DES_tjpcov_bm/"
 OUTDIR = "tests/tmp/"
 INPUT_YML = "tests/data/conf_covariance_gaussian_fourier_nmt.yaml"

--- a/tjpcov/covariance_gaussian_fsky.py
+++ b/tjpcov/covariance_gaussian_fsky.py
@@ -50,10 +50,8 @@ class FourierGaussianFsky(CovarianceFourier):
             ell_edges = out[2]
             return ell, ell_eff, ell_edges
         else:
-            warnings.warn(
-                "No bandpower windows found, \
-                           falling back to linear method"
-            )
+            warnings.warn("No bandpower windows found, \
+                           falling back to linear method")
             ell_eff = self.get_ell_eff()
             nbpw = ell_eff.size
 

--- a/tjpcov/wigner_transform.py
+++ b/tjpcov/wigner_transform.py
@@ -11,7 +11,6 @@ from scipy.special import binom
 from scipy.special import eval_jacobi as jacobi
 from scipy.special import jn
 
-
 # FIXME:
 # 1. Do we need to pass logger?
 # 2. Need to add inverse transform functionality.


### PR DESCRIPTION
Readthedocs will depecrate in June 1, 2026 the `build.os: ubuntu-20.04`. They recommended 

> What do I need to do?
> Update your .readthedocs.yaml to use a newer supported image. For most projects, we recommend:
> 
> build:
>   os: ubuntu-24.04
> 
> Read the Docs currently supports ubuntu-22.04, ubuntu-24.04, and ubuntu-lts-latest for build.os. See all options in the docs: https://docs.readthedocs.io/en/stable/config-file/v2.html#build-os

I have also bumped the python version to a current one.

Edit: I have also bumped the actions versions since they were going to stop working in June due to being run in a new Node24.js node. I also had to relax the comparison of the `ell_eff` for Mac, due to a most likely floating point issue.